### PR TITLE
fix formula URL in example pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -6,7 +6,7 @@ alcali:
     name: alcali
     init_delay: null  # Gunicorn may take some delay to pop, adjust here
   deploy:
-    repository: https://github.com/latenighttales/alcali.git
+    repository: https://github.com/saltstack-formulas/alcali-formula
     rev: v3003.1.0  # You can specify branch or tag
     force_reset: False
     user: alcali


### PR DESCRIPTION
This just updates the URL from https://github.com/latenighttales/alcali-formula to https://github.com/saltstack-formulas/alcali-formula